### PR TITLE
docs: fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Swiftest 
 
 ---
-Swiftest is a software packaged designed to model the long-term dynamical dynamics of n-body systems with a dominant central body, 
+Swiftest is a software package designed to model the long-term dynamics of n-body systems with a dominant central body, 
 like the solar system. Swiftest is a re-write of the [Swifter](https://www.boulder.swri.edu/swifter/) software package that 
 incorporates modern programming techniques and performance improvements. 
 


### PR DESCRIPTION
## Summary

Fix 2 issues in 1 file:

- **README.md**: "software packaged designed" → "software package designed" (extra 'd')
- **README.md**: "long-term dynamical dynamics" → "long-term dynamics" (redundant word)

No functional changes — documentation only.